### PR TITLE
add bluetooth indicator extension

### DIFF
--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -2,7 +2,7 @@
 
 # To only build some of the extensions, remove
 # the unwanted ones from the $extensions variable.
-extensions=('brightness' 'volume' 'user' 'location')
+extensions=('brightness' 'volume' 'user' 'location' 'bluetooth')
 pkgbase='$appname-git'
 for e in ${extensions[@]}; do
   local pkg=gnome-shell-extension-hide-$e-git

--- a/extension.js.in
+++ b/extension.js.in
@@ -1,4 +1,4 @@
-const item = imports.ui.main.panel.statusArea.aggregateMenu.${item}.actor;
+const item = imports.ui.main.panel.statusArea.aggregateMenu.${item};
 
 let registration;
 

--- a/extensions.csv
+++ b/extensions.csv
@@ -1,5 +1,6 @@
 name,author,item,description
-Brightness Slider,xzs,_brightness._item,Hides the brightness slider from the aggregate menu
-Location Options,xzs,_location._item,Hides the location options from the aggregate menu
-User Switch,xzs,_system._switchUserSubMenu,"Hides the switch user sub menu from the aggregated menu, removing the logout option. Handy for a single-user system"
-Volume Controls,xzs,_volume._volumeMenu,Hides the volume controls from the aggregate menu. The volume can still be adjusted via hardware keys
+Brightness Slider,xzs,_brightness._item.actor,Hides the brightness slider from the aggregate menu
+Location Options,xzs,_location._item.actor,Hides the location options from the aggregate menu
+User Switch,xzs,_system._switchUserSubMenu.actor,"Hides the switch user sub menu from the aggregated menu, removing the logout option. Handy for a single-user system"
+Volume Controls,xzs,_volume._volumeMenu.actor,Hides the volume controls from the aggregate menu. The volume can still be adjusted via hardware keys
+Bluetooth Indicator,brad,_bluetooth._indicator,Hides the bluetooth indicator from the aggregate menu


### PR DESCRIPTION
@dffischer This adds a line for an extension that hides the bluetooth indicator. It needs no `.actor` postfix so I removed that from `extension.js.in` and adjusted the other items to have `.actor` at the end.